### PR TITLE
Typo in Data Field Format example

### DIFF
--- a/MaxMind-DB-spec.md
+++ b/MaxMind-DB-spec.md
@@ -422,7 +422,7 @@ tell us the type:
 
     001XXXXX          pointer
     010XXXXX          UTF-8 string
-    010XXXXX          unsigned 32-bit int (ASCII)
+    110XXXXX          unsigned 32-bit int (ASCII)
     000XXXXX 00000011 unsigned 128-bit int (binary)
     000XXXXX 00000100 array
     000XXXXX 00000110 end marker


### PR DESCRIPTION
Based on the documentation below
```
The type numbers for our integer types are:

unsigned 16-bit int - 5
unsigned 32-bit int - 6
signed 32-bit int - 8
unsigned 64-bit int - 9
unsigned 128-bit int - 10
```

The example `010XXXXX unsigned 32-bit int (ASCII)` seems wrong.