### PR TITLE
Fix source data that doesn't match test data

### DIFF
--- a/source-data/GeoLite2-ASN-Test.json
+++ b/source-data/GeoLite2-ASN-Test.json
@@ -7,7 +7,8 @@
    },
    {
       "12.81.92.0/22" : {
-         "autonomous_system_number" : 7018
+         "autonomous_system_number" : 7018,
+         "autonomous_system_organization" : "AT&T Services"
       }
    },
    {

--- a/source-data/GeoLite2-ASN-Test.json
+++ b/source-data/GeoLite2-ASN-Test.json
@@ -4098,40 +4098,5 @@
          "autonomous_system_number" : 237,
          "autonomous_system_organization" : "Merit Network Inc."
       }
-   },
-   {
-      "::1.128.0.0/107" : {
-         "autonomous_system_number" : 1221,
-         "autonomous_system_organization" : "Telstra Pty Ltd"
-      }
-   },
-   {
-      "::12.81.92.0/118" : {
-         "autonomous_system_number" : 7018,
-         "autonomous_system_organization" : "AT&T Services"
-      }
-   },
-   {
-      "::12.81.96.0/115" : {
-         "autonomous_system_number" : 7018
-      }
-   },
-   {
-      "2600:6000::/20" : {
-         "autonomous_system_number" : 237,
-         "autonomous_system_organization" : "Merit Network Inc."
-      }
-   },
-   {
-      "2600:7000::/24" : {
-         "autonomous_system_number" : 6939,
-         "autonomous_system_organization" : "Hurricane Electric, Inc."
-      }
-   },
-   {
-      "2600:7100::/24" : {
-         "autonomous_system_number" : 237,
-         "autonomous_system_organization" : "Merit Network Inc."
-      }
    }
 ]


### PR DESCRIPTION
The [second test case specified under the "GeoLite2-ASN-test.json"](https://github.com/maxmind/MaxMind-DB/blob/44fba0d/source-data/GeoLite2-ASN-Test.json#L8-L12) is missing the `autonomous_system_organization` field, which
"GeoLite2-ASN-Test.mmdb" returns for `12.81.92.0`.

(I caught this upon updating my MMDB decoder's import of MaxMind-DB, which I hadn't done since May 2020 - so I'm not sure when this was introduced.)