### PR TITLE
Update minimum Go version to 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         # We don't test on macOS and windows as the database builds aren't
         # repeatable there for some reason. As such, tests fail. It'd
         # probably be worth looking into this at some point.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 run:
   # This is needed for precious, which may run multiple instances
   # in parallel
-  go: "1.24"
+  go: "1.25"
   tests: true
   allow-parallel-runners: true
 linters:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maxmind/MaxMind-DB
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/maxmind/mmdbwriter v1.2.0


### PR DESCRIPTION
Bump the go directive in go.mod, switch the CI matrix to test 1.25.x and 1.26.x, and update the golangci-lint go target to match.