### PR TITLE
Validate and update links (STF-557)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,32 @@
+name: Links
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 13 * * 1" # weekly, to catch external link rot without a commit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: false
+
+      # Install only lychee (not the repo's full toolchain) and run the check.
+      - name: Check links
+        env:
+          MISE_AUTO_INSTALL: "false"
+        run: |
+          mise install lychee
+          mise run check-links

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docs/.hugo_build.lock
 docs/public/
 *.swp
 /cmd/write-test-data/write-test-data
+.lycheecache

--- a/MaxMind-DB-spec.md
+++ b/MaxMind-DB-spec.md
@@ -264,11 +264,11 @@ mappings between IPv4 and IPv6.
 The strategy that MaxMind uses for its GeoIP databases is to include a pointer
 from the `::ffff:0:0/96` subnet to the root node of the IPv4 address space in
 the tree. This accounts for the
-[IPv4-mapped IPv6 address](http://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses).
+[IPv4-mapped IPv6 address](https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses).
 
 MaxMind also includes a pointer from the `2002::/16` subnet to the root node of
 the IPv4 address space in the tree. This accounts for the
-[6to4 mapping](http://en.wikipedia.org/wiki/6to4) subnet.
+[6to4 mapping](https://en.wikipedia.org/wiki/6to4) subnet.
 
 Database creators are encouraged to document whether they are doing something
 similar for their databases.
@@ -564,6 +564,6 @@ This specification was created by the following authors:
 
 This work is licensed under the Creative Commons Attribution-ShareAlike 3.0
 Unported License. To view a copy of this license, visit
-[http://creativecommons.org/licenses/by-sa/3.0/](http://creativecommons.org/licenses/by-sa/3.0/)
+[https://creativecommons.org/licenses/by-sa/3.0/](https://creativecommons.org/licenses/by-sa/3.0/)
 or send a letter to Creative Commons, 444 Castro Street, Suite 900, Mountain
 View, California, 94041, USA

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,54 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/#/usage/config
+#
+# Run locally with:
+#   lychee './**/*.md'
+
+# Include URL fragments in checks
+include_fragments = true
+
+# Don't allow any redirects, so links that have moved are surfaced and can be
+# updated to their canonical destination.
+max_redirects = 0
+
+# Accept these HTTP status codes
+# 100-103: Informational responses
+# 200-299: Success responses
+# 403: Forbidden (some sites use this for rate limiting)
+# 429: Too Many Requests
+# 500-599: Server errors (temporary issues shouldn't fail CI)
+# 999: LinkedIn's custom status code
+accept = ["100..=103", "200..=299", "403", "429", "500..=599", "999"]
+
+# Exclude URL patterns from checking (treated as regular expressions)
+exclude = [
+    # GitHub blob URLs with line-number fragments (not parseable as page anchors)
+    '^https://github\.com/[^/]+/[^/]+/blob/[0-9a-fA-F]+/.+#L\d+$',
+    # Local / placeholder URLs
+    '^file://',
+    '^https?://example\.(com|org|net)',
+    '^http://localhost',
+    '127\.0\.0\.1',
+]
+
+# Exclude file paths from getting checked (regular expressions, matched against
+# the path relative to the working directory). Patterns are segment-anchored
+# with (^|/) so short names like "build" don't match unintended paths.
+#
+# Note: the check-links task only globs Markdown, so the large generated test
+# fixtures (test-data/*.mmdb, source-data/*.json) are never scanned. The
+# README.md files under test-data/ and bad-data/ are real docs and remain in
+# scope. These entries guard against accidentally widening the globs.
+exclude_path = [
+    '(^|/)source-data/',
+    '(^|/)vendor/',
+    '(^|/)build/',
+    '(^|/)public/',
+]
+
+# Cache results for 1 day to speed up repeated checks
+cache = true
+max_cache_age = "1d"
+
+# Skip missing input files instead of erroring
+skip_missing = true

--- a/mise.lock
+++ b/mise.lock
@@ -86,38 +86,6 @@ url = "https://github.com/houseabsolute/precious/releases/download/v0.10.2/preci
 url_api = "https://api.github.com/repos/houseabsolute/precious/releases/assets/345520544"
 
 [[tools.go]]
-version = "1.26.0"
-backend = "core:go"
-
-[tools.go."platforms.linux-arm64"]
-checksum = "sha256:bd03b743eb6eb4193ea3c3fd3956546bf0e3ca5b7076c8226334afe6b75704cd"
-url = "https://dl.google.com/go/go1.26.0.linux-arm64.tar.gz"
-
-[tools.go."platforms.linux-arm64-musl"]
-checksum = "sha256:bd03b743eb6eb4193ea3c3fd3956546bf0e3ca5b7076c8226334afe6b75704cd"
-url = "https://dl.google.com/go/go1.26.0.linux-arm64.tar.gz"
-
-[tools.go."platforms.linux-x64"]
-checksum = "sha256:aac1b08a0fb0c4e0a7c1555beb7b59180b05dfc5a3d62e40e9de90cd42f88235"
-url = "https://dl.google.com/go/go1.26.0.linux-amd64.tar.gz"
-
-[tools.go."platforms.linux-x64-musl"]
-checksum = "sha256:aac1b08a0fb0c4e0a7c1555beb7b59180b05dfc5a3d62e40e9de90cd42f88235"
-url = "https://dl.google.com/go/go1.26.0.linux-amd64.tar.gz"
-
-[tools.go."platforms.macos-arm64"]
-checksum = "sha256:b1640525dfe68f066d56f200bef7bf4dce955a1a893bd061de6754c211431023"
-url = "https://dl.google.com/go/go1.26.0.darwin-arm64.tar.gz"
-
-[tools.go."platforms.macos-x64"]
-checksum = "sha256:1ca28b7703cbea05a65b2a1d92d6b308610ef92f8824578a0874f2e60c9d5a22"
-url = "https://dl.google.com/go/go1.26.0.darwin-amd64.tar.gz"
-
-[tools.go."platforms.windows-x64"]
-checksum = "sha256:9bbe0fc64236b2b51f6255c05c4232532b8ecc0e6d2e00950bd3021d8a4d07d4"
-url = "https://dl.google.com/go/go1.26.0.windows-amd64.zip"
-
-[[tools.go]]
 version = "1.26.1"
 backend = "core:go"
 
@@ -181,37 +149,33 @@ url = "https://github.com/gohugoio/hugo/releases/download/v0.157.0/hugo_0.157.0_
 checksum = "sha256:3aaf98a9f504047fb7f2d5c01c649012a9763e02c60dcc30f56342b8bfa0caac"
 url = "https://github.com/gohugoio/hugo/releases/download/v0.157.0/hugo_0.157.0_windows-amd64.zip"
 
-[[tools.node]]
-version = "25.7.0"
-backend = "core:node"
+[[tools.lychee]]
+version = "0.23.0"
+backend = "aqua:lycheeverse/lychee"
 
-[tools.node."platforms.linux-arm64"]
-checksum = "sha256:3a73c9145547b5d2e29491b0ed6a37b95306b784eb83cdb2361f1e2e76fa237f"
-url = "https://nodejs.org/dist/v25.7.0/node-v25.7.0-linux-arm64.tar.gz"
+[tools.lychee."platforms.linux-arm64"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
 
-[tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:3a73c9145547b5d2e29491b0ed6a37b95306b784eb83cdb2361f1e2e76fa237f"
-url = "https://nodejs.org/dist/v25.7.0/node-v25.7.0-linux-arm64.tar.gz"
+[tools.lychee."platforms.linux-arm64-musl"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
 
-[tools.node."platforms.linux-x64"]
-checksum = "sha256:033ad3a740d62d3c7e3aaa1fecfeec16a719d4af33ab030666bf171057b070d9"
-url = "https://nodejs.org/dist/v25.7.0/node-v25.7.0-linux-x64.tar.gz"
+[tools.lychee."platforms.linux-x64"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
 
-[tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:033ad3a740d62d3c7e3aaa1fecfeec16a719d4af33ab030666bf171057b070d9"
-url = "https://nodejs.org/dist/v25.7.0/node-v25.7.0-linux-x64.tar.gz"
+[tools.lychee."platforms.linux-x64-musl"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
 
-[tools.node."platforms.macos-arm64"]
-checksum = "sha256:d4e3cfe5e6bddda41ba0c683e37329632465b93371ddc538c763578758d5bc35"
-url = "https://nodejs.org/dist/v25.7.0/node-v25.7.0-darwin-arm64.tar.gz"
+[tools.lychee."platforms.macos-arm64"]
+checksum = "sha256:4c8034900e11083b68ac6f6582c377ff1f704e268991999e09d717973e493e7f"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-arm64-macos.dmg"
 
-[tools.node."platforms.macos-x64"]
-checksum = "sha256:f83929f4a84ae5a88c2a5333466b100dd101658063592497626ae9eea15b3b1b"
-url = "https://nodejs.org/dist/v25.7.0/node-v25.7.0-darwin-x64.tar.gz"
-
-[tools.node."platforms.windows-x64"]
-checksum = "sha256:4a66eac416c30474fe9c3f0ef7d4ffc85a8797cbc35f6b8566dfbce02789a9c4"
-url = "https://nodejs.org/dist/v25.7.0/node-v25.7.0-win-x64.zip"
+[tools.lychee."platforms.windows-x64"]
+checksum = "sha256:0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-windows.exe"
 
 [[tools.node]]
 version = "25.8.0"

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ disable_backends = [
 go = "latest"
 hugo = "latest"
 node = "latest"
+lychee = "latest"
 "github:golangci/golangci-lint" = "latest"
 "github:houseabsolute/precious" = "latest"
 "npm:prettier" = "latest"
@@ -19,6 +20,10 @@ enter = "mise install --quiet"
 [[watch_files]]
 patterns = ["mise.toml", "mise.lock"]
 run = "mise install --quiet"
+
+[tasks.check-links]
+description = "Check links with lychee"
+run = "lychee --no-progress './**/*.md'"
 
 [tasks.build-docs]
 description = "Build the spec site with Hugo"

--- a/test-data/README.md
+++ b/test-data/README.md
@@ -1,7 +1,7 @@
 ## How to generate test data
 
 Use the
-[write-test-data](https://github.com/maxmind/MaxMind-DB/blob/main/cmd/write-test-data)
+[write-test-data](https://github.com/maxmind/MaxMind-DB/tree/main/cmd/write-test-data)
 go tool to create a small set of test databases with a variety of data and
 record sizes.
 


### PR DESCRIPTION
Adds a lychee link checker (config + CI workflow) and fixes stale/redirecting links across the repo's Markdown.

## Tooling
- `lychee.toml`: `max_redirects = 0` (surfaces moved links), accepts 5xx/403/429/999, segment-anchored `exclude_path`. Only Markdown is scanned, so the large generated fixtures under `test-data/` and `source-data/` are never checked; the `README.md` files there remain in scope.
- `lychee` pinned to `0.23.0` in `mise.toml` (with `mise.lock` updated); CI runs it via `mise run check-links` in `.github/workflows/links.yml` (push, PR, weekly cron, manual dispatch).
- `.lycheecache` added to `.gitignore`.

## Link fixes (old -> new)
- `MaxMind-DB-spec.md`: `http://creativecommons.org/licenses/by-sa/3.0/` -> `https://creativecommons.org/licenses/by-sa/3.0/`
- `MaxMind-DB-spec.md`: `http://en.wikipedia.org/wiki/6to4` -> `https://en.wikipedia.org/wiki/6to4`
- `MaxMind-DB-spec.md`: `http://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses` -> `https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses`
- `test-data/README.md`: `https://github.com/maxmind/MaxMind-DB/blob/main/cmd/write-test-data` -> `https://github.com/maxmind/MaxMind-DB/tree/main/cmd/write-test-data`

Final lychee run: `21 Total, 16 OK, 0 Errors, 5 Excluded` (excluded = local LICENSE `file://` links + `mailto:` addresses).

Part of STF-557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)